### PR TITLE
feat: add diff() method for raw PR diff

### DIFF
--- a/src/PullRequest.php
+++ b/src/PullRequest.php
@@ -16,6 +16,7 @@ use ConduitUI\Pr\Requests\GetCommitCheckRuns;
 use ConduitUI\Pr\Requests\GetIssueComments;
 use ConduitUI\Pr\Requests\GetPullRequestComments;
 use ConduitUI\Pr\Requests\GetPullRequestCommits;
+use ConduitUI\Pr\Requests\GetPullRequestDiff;
 use ConduitUI\Pr\Requests\GetPullRequestFiles;
 use ConduitUI\Pr\Requests\GetPullRequestReviews;
 use ConduitUI\Pr\Requests\MergePullRequest;
@@ -189,6 +190,20 @@ class PullRequest
         ));
 
         return array_values($response->json());
+    }
+
+    /**
+     * Get the raw diff text for this pull request.
+     */
+    public function diff(): string
+    {
+        $response = $this->connector->send(new GetPullRequestDiff(
+            $this->owner,
+            $this->repo,
+            $this->data->number
+        ));
+
+        return $response->body();
     }
 
     /**

--- a/src/Requests/GetPullRequestDiff.php
+++ b/src/Requests/GetPullRequestDiff.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Pr\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+class GetPullRequestDiff extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected string $owner,
+        protected string $repo,
+        protected int $number,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return "/repos/{$this->owner}/{$this->repo}/pulls/{$this->number}";
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function defaultHeaders(): array
+    {
+        return [
+            'Accept' => 'application/vnd.github.v3.diff',
+        ];
+    }
+}


### PR DESCRIPTION
Implements Issue #1 by adding a new `diff()` method to the PullRequest wrapper class that returns the raw diff text from GitHub.

## Changes

- Added `GetPullRequestDiff` request class with `application/vnd.github.v3.diff` Accept header
- Added `diff(): string` method to `PullRequest` wrapper that returns raw diff text
- Added test coverage in `PullRequestWrapperTest.php`
- Updated `MockResponse` and `TestConnector` to support body content responses

## Test Plan

- All existing tests pass
- New test added for `diff()` method
- PHPStan analysis passes (level 8)
- Code style check passes (Laravel Pint)

Fixes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for retrieving raw pull request diffs. Users can now fetch the complete diff content for any pull request, enabling detailed review of code changes in their raw format. This new capability complements existing pull request functionality for accessing files and commit information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->