### PR TITLE
feat: return typed DTOs from files/checks/commits

### DIFF
--- a/src/DataTransferObjects/Commit.php
+++ b/src/DataTransferObjects/Commit.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Pr\DataTransferObjects;
+
+class Commit
+{
+    public function __construct(
+        public readonly string $sha,
+        public readonly string $message,
+        public readonly CommitAuthor $author,
+        public readonly CommitAuthor $committer,
+        public readonly string $htmlUrl,
+        public readonly ?User $githubAuthor,
+        public readonly ?User $githubCommitter,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            sha: $data['sha'],
+            message: $data['commit']['message'],
+            author: CommitAuthor::fromArray($data['commit']['author']),
+            committer: CommitAuthor::fromArray($data['commit']['committer']),
+            htmlUrl: $data['html_url'],
+            githubAuthor: isset($data['author']) ? User::fromArray($data['author']) : null,
+            githubCommitter: isset($data['committer']) ? User::fromArray($data['committer']) : null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'sha' => $this->sha,
+            'commit' => [
+                'message' => $this->message,
+                'author' => $this->author->toArray(),
+                'committer' => $this->committer->toArray(),
+            ],
+            'html_url' => $this->htmlUrl,
+            'author' => $this->githubAuthor?->toArray(),
+            'committer' => $this->githubCommitter?->toArray(),
+        ];
+    }
+}

--- a/src/DataTransferObjects/CommitAuthor.php
+++ b/src/DataTransferObjects/CommitAuthor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Pr\DataTransferObjects;
+
+use DateTimeImmutable;
+
+class CommitAuthor
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $email,
+        public readonly DateTimeImmutable $date,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            name: $data['name'],
+            email: $data['email'],
+            date: new DateTimeImmutable($data['date']),
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'email' => $this->email,
+            'date' => $this->date->format('c'),
+        ];
+    }
+}

--- a/src/DataTransferObjects/File.php
+++ b/src/DataTransferObjects/File.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Pr\DataTransferObjects;
+
+class File
+{
+    public function __construct(
+        public readonly string $sha,
+        public readonly string $filename,
+        public readonly string $status,
+        public readonly int $additions,
+        public readonly int $deletions,
+        public readonly int $changes,
+        public readonly string $blobUrl,
+        public readonly string $rawUrl,
+        public readonly string $contentsUrl,
+        public readonly ?string $patch,
+        public readonly ?string $previousFilename,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            sha: $data['sha'],
+            filename: $data['filename'],
+            status: $data['status'],
+            additions: $data['additions'],
+            deletions: $data['deletions'],
+            changes: $data['changes'],
+            blobUrl: $data['blob_url'],
+            rawUrl: $data['raw_url'],
+            contentsUrl: $data['contents_url'],
+            patch: $data['patch'] ?? null,
+            previousFilename: $data['previous_filename'] ?? null,
+        );
+    }
+
+    public function isAdded(): bool
+    {
+        return $this->status === 'added';
+    }
+
+    public function isRemoved(): bool
+    {
+        return $this->status === 'removed';
+    }
+
+    public function isModified(): bool
+    {
+        return $this->status === 'modified';
+    }
+
+    public function isRenamed(): bool
+    {
+        return $this->status === 'renamed';
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'sha' => $this->sha,
+            'filename' => $this->filename,
+            'status' => $this->status,
+            'additions' => $this->additions,
+            'deletions' => $this->deletions,
+            'changes' => $this->changes,
+            'blob_url' => $this->blobUrl,
+            'raw_url' => $this->rawUrl,
+            'contents_url' => $this->contentsUrl,
+            'patch' => $this->patch,
+            'previous_filename' => $this->previousFilename,
+        ];
+    }
+}

--- a/src/PullRequest.php
+++ b/src/PullRequest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace ConduitUI\Pr;
 
 use ConduitUi\GitHubConnector\Connector;
+use ConduitUI\Pr\DataTransferObjects\CheckRun;
 use ConduitUI\Pr\DataTransferObjects\Comment;
+use ConduitUI\Pr\DataTransferObjects\Commit;
+use ConduitUI\Pr\DataTransferObjects\File;
 use ConduitUI\Pr\DataTransferObjects\PullRequest as PullRequestData;
 use ConduitUI\Pr\DataTransferObjects\Review;
 use ConduitUI\Pr\Requests\AddIssueLabels;
@@ -182,7 +185,7 @@ class PullRequest
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return array<int, File>
      */
     public function files(): array
     {
@@ -192,10 +195,14 @@ class PullRequest
             $this->data->number
         ));
 
-        return array_values($response->json());
+        return array_values(array_map(
+            fn (array $data) => File::fromArray($data),
+            $response->json()
+        ));
     }
 
     /**
+/**
      * Get the raw diff text for this pull request.
      */
     public function diff(): string
@@ -210,7 +217,7 @@ class PullRequest
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return array<int, CheckRun>
      */
     public function checks(): array
     {
@@ -220,13 +227,18 @@ class PullRequest
             $this->data->head->sha
         ));
 
-        return $response->json()['check_runs'] ?? [];
+        $checkRuns = $response->json()['check_runs'] ?? [];
+
+        return array_values(array_map(
+            fn (array $data) => CheckRun::fromArray($data),
+            $checkRuns
+        ));
     }
 
     /**
      * Get all commits in this pull request (paginated, fetches all pages).
      *
-     * @return array<int, array<string, mixed>>
+     * @return array<int, Commit>
      */
     public function commits(): array
     {
@@ -253,7 +265,10 @@ class PullRequest
             $page++;
         } while (count($commits) === $perPage);
 
-        return array_values($allCommits);
+        return array_values(array_map(
+            fn (array $data) => Commit::fromArray($data),
+            $allCommits
+        ));
     }
 
     /**

--- a/tests/Unit/DataTransferObjects/CommitAuthorTest.php
+++ b/tests/Unit/DataTransferObjects/CommitAuthorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Pr\DataTransferObjects\CommitAuthor;
+
+it('can create commit author from array', function () {
+    $data = [
+        'name' => 'John Doe',
+        'email' => 'john@example.com',
+        'date' => '2025-01-01T10:00:00Z',
+    ];
+
+    $author = CommitAuthor::fromArray($data);
+
+    expect($author->name)->toBe('John Doe')
+        ->and($author->email)->toBe('john@example.com')
+        ->and($author->date)->toBeInstanceOf(DateTimeImmutable::class)
+        ->and($author->date->format('Y-m-d'))->toBe('2025-01-01');
+});
+
+it('can convert commit author to array', function () {
+    $data = [
+        'name' => 'Jane Smith',
+        'email' => 'jane@example.com',
+        'date' => '2025-01-15T14:30:00Z',
+    ];
+
+    $author = CommitAuthor::fromArray($data);
+    $result = $author->toArray();
+
+    expect($result['name'])->toBe('Jane Smith')
+        ->and($result['email'])->toBe('jane@example.com')
+        ->and($result['date'])->toBe('2025-01-15T14:30:00+00:00');
+});

--- a/tests/Unit/DataTransferObjects/CommitTest.php
+++ b/tests/Unit/DataTransferObjects/CommitTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Pr\DataTransferObjects\Commit;
+use ConduitUI\Pr\DataTransferObjects\CommitAuthor;
+use ConduitUI\Pr\DataTransferObjects\User;
+
+it('can create commit from array with github users', function () {
+    $data = [
+        'sha' => 'abc123def456',
+        'commit' => [
+            'message' => 'Initial commit',
+            'author' => [
+                'name' => 'John Doe',
+                'email' => 'john@example.com',
+                'date' => '2025-01-01T10:00:00Z',
+            ],
+            'committer' => [
+                'name' => 'Jane Smith',
+                'email' => 'jane@example.com',
+                'date' => '2025-01-01T10:05:00Z',
+            ],
+        ],
+        'html_url' => 'https://github.com/owner/repo/commit/abc123def456',
+        'author' => [
+            'id' => 1,
+            'login' => 'johndoe',
+            'avatar_url' => 'https://example.com/avatar.jpg',
+            'html_url' => 'https://github.com/johndoe',
+            'type' => 'User',
+        ],
+        'committer' => [
+            'id' => 2,
+            'login' => 'janesmith',
+            'avatar_url' => 'https://example.com/avatar2.jpg',
+            'html_url' => 'https://github.com/janesmith',
+            'type' => 'User',
+        ],
+    ];
+
+    $commit = Commit::fromArray($data);
+
+    expect($commit->sha)->toBe('abc123def456')
+        ->and($commit->message)->toBe('Initial commit')
+        ->and($commit->author)->toBeInstanceOf(CommitAuthor::class)
+        ->and($commit->author->name)->toBe('John Doe')
+        ->and($commit->author->email)->toBe('john@example.com')
+        ->and($commit->committer)->toBeInstanceOf(CommitAuthor::class)
+        ->and($commit->committer->name)->toBe('Jane Smith')
+        ->and($commit->htmlUrl)->toBe('https://github.com/owner/repo/commit/abc123def456')
+        ->and($commit->githubAuthor)->toBeInstanceOf(User::class)
+        ->and($commit->githubAuthor->login)->toBe('johndoe')
+        ->and($commit->githubCommitter)->toBeInstanceOf(User::class)
+        ->and($commit->githubCommitter->login)->toBe('janesmith');
+});
+
+it('can create commit without github users', function () {
+    $data = [
+        'sha' => 'def456abc789',
+        'commit' => [
+            'message' => 'Fix bug',
+            'author' => [
+                'name' => 'External Author',
+                'email' => 'external@example.com',
+                'date' => '2025-01-02T11:00:00Z',
+            ],
+            'committer' => [
+                'name' => 'External Committer',
+                'email' => 'committer@example.com',
+                'date' => '2025-01-02T11:05:00Z',
+            ],
+        ],
+        'html_url' => 'https://github.com/owner/repo/commit/def456abc789',
+    ];
+
+    $commit = Commit::fromArray($data);
+
+    expect($commit->sha)->toBe('def456abc789')
+        ->and($commit->message)->toBe('Fix bug')
+        ->and($commit->githubAuthor)->toBeNull()
+        ->and($commit->githubCommitter)->toBeNull();
+});
+
+it('can convert commit to array', function () {
+    $data = [
+        'sha' => 'abc123',
+        'commit' => [
+            'message' => 'Test commit',
+            'author' => [
+                'name' => 'Test Author',
+                'email' => 'test@example.com',
+                'date' => '2025-01-01T12:00:00Z',
+            ],
+            'committer' => [
+                'name' => 'Test Committer',
+                'email' => 'committer@example.com',
+                'date' => '2025-01-01T12:05:00Z',
+            ],
+        ],
+        'html_url' => 'https://github.com/owner/repo/commit/abc123',
+        'author' => [
+            'id' => 1,
+            'login' => 'testuser',
+            'avatar_url' => 'https://example.com/avatar.jpg',
+            'html_url' => 'https://github.com/testuser',
+            'type' => 'User',
+        ],
+        'committer' => [
+            'id' => 2,
+            'login' => 'testcommitter',
+            'avatar_url' => 'https://example.com/avatar2.jpg',
+            'html_url' => 'https://github.com/testcommitter',
+            'type' => 'User',
+        ],
+    ];
+
+    $commit = Commit::fromArray($data);
+    $result = $commit->toArray();
+
+    expect($result['sha'])->toBe('abc123')
+        ->and($result['commit']['message'])->toBe('Test commit')
+        ->and($result['commit']['author']['name'])->toBe('Test Author')
+        ->and($result['commit']['committer']['name'])->toBe('Test Committer')
+        ->and($result['html_url'])->toBe('https://github.com/owner/repo/commit/abc123')
+        ->and($result['author']['login'])->toBe('testuser')
+        ->and($result['committer']['login'])->toBe('testcommitter');
+});

--- a/tests/Unit/DataTransferObjects/FileTest.php
+++ b/tests/Unit/DataTransferObjects/FileTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Pr\DataTransferObjects\File;
+
+it('can create file from array', function () {
+    $data = [
+        'sha' => 'abc123',
+        'filename' => 'src/Example.php',
+        'status' => 'modified',
+        'additions' => 10,
+        'deletions' => 5,
+        'changes' => 15,
+        'blob_url' => 'https://github.com/owner/repo/blob/abc123/src/Example.php',
+        'raw_url' => 'https://github.com/owner/repo/raw/abc123/src/Example.php',
+        'contents_url' => 'https://api.github.com/repos/owner/repo/contents/src/Example.php',
+        'patch' => '@@ -1,5 +1,10 @@',
+    ];
+
+    $file = File::fromArray($data);
+
+    expect($file->sha)->toBe('abc123')
+        ->and($file->filename)->toBe('src/Example.php')
+        ->and($file->status)->toBe('modified')
+        ->and($file->additions)->toBe(10)
+        ->and($file->deletions)->toBe(5)
+        ->and($file->changes)->toBe(15)
+        ->and($file->blobUrl)->toBe('https://github.com/owner/repo/blob/abc123/src/Example.php')
+        ->and($file->rawUrl)->toBe('https://github.com/owner/repo/raw/abc123/src/Example.php')
+        ->and($file->contentsUrl)->toBe('https://api.github.com/repos/owner/repo/contents/src/Example.php')
+        ->and($file->patch)->toBe('@@ -1,5 +1,10 @@')
+        ->and($file->previousFilename)->toBeNull();
+});
+
+it('can create file with optional fields', function () {
+    $data = [
+        'sha' => 'def456',
+        'filename' => 'src/NewName.php',
+        'status' => 'renamed',
+        'additions' => 0,
+        'deletions' => 0,
+        'changes' => 0,
+        'blob_url' => 'https://github.com/owner/repo/blob/def456/src/NewName.php',
+        'raw_url' => 'https://github.com/owner/repo/raw/def456/src/NewName.php',
+        'contents_url' => 'https://api.github.com/repos/owner/repo/contents/src/NewName.php',
+        'previous_filename' => 'src/OldName.php',
+    ];
+
+    $file = File::fromArray($data);
+
+    expect($file->previousFilename)->toBe('src/OldName.php')
+        ->and($file->patch)->toBeNull();
+});
+
+it('can check if file is added', function () {
+    $file = File::fromArray([
+        'sha' => 'abc123',
+        'filename' => 'new.php',
+        'status' => 'added',
+        'additions' => 10,
+        'deletions' => 0,
+        'changes' => 10,
+        'blob_url' => 'https://example.com',
+        'raw_url' => 'https://example.com',
+        'contents_url' => 'https://example.com',
+    ]);
+
+    expect($file->isAdded())->toBeTrue()
+        ->and($file->isRemoved())->toBeFalse()
+        ->and($file->isModified())->toBeFalse()
+        ->and($file->isRenamed())->toBeFalse();
+});
+
+it('can check if file is removed', function () {
+    $file = File::fromArray([
+        'sha' => 'abc123',
+        'filename' => 'deleted.php',
+        'status' => 'removed',
+        'additions' => 0,
+        'deletions' => 10,
+        'changes' => 10,
+        'blob_url' => 'https://example.com',
+        'raw_url' => 'https://example.com',
+        'contents_url' => 'https://example.com',
+    ]);
+
+    expect($file->isRemoved())->toBeTrue()
+        ->and($file->isAdded())->toBeFalse()
+        ->and($file->isModified())->toBeFalse()
+        ->and($file->isRenamed())->toBeFalse();
+});
+
+it('can check if file is modified', function () {
+    $file = File::fromArray([
+        'sha' => 'abc123',
+        'filename' => 'changed.php',
+        'status' => 'modified',
+        'additions' => 5,
+        'deletions' => 3,
+        'changes' => 8,
+        'blob_url' => 'https://example.com',
+        'raw_url' => 'https://example.com',
+        'contents_url' => 'https://example.com',
+    ]);
+
+    expect($file->isModified())->toBeTrue()
+        ->and($file->isAdded())->toBeFalse()
+        ->and($file->isRemoved())->toBeFalse()
+        ->and($file->isRenamed())->toBeFalse();
+});
+
+it('can check if file is renamed', function () {
+    $file = File::fromArray([
+        'sha' => 'abc123',
+        'filename' => 'new.php',
+        'status' => 'renamed',
+        'additions' => 0,
+        'deletions' => 0,
+        'changes' => 0,
+        'blob_url' => 'https://example.com',
+        'raw_url' => 'https://example.com',
+        'contents_url' => 'https://example.com',
+        'previous_filename' => 'old.php',
+    ]);
+
+    expect($file->isRenamed())->toBeTrue()
+        ->and($file->isAdded())->toBeFalse()
+        ->and($file->isRemoved())->toBeFalse()
+        ->and($file->isModified())->toBeFalse();
+});
+
+it('can convert file to array', function () {
+    $data = [
+        'sha' => 'abc123',
+        'filename' => 'test.php',
+        'status' => 'modified',
+        'additions' => 10,
+        'deletions' => 5,
+        'changes' => 15,
+        'blob_url' => 'https://example.com/blob',
+        'raw_url' => 'https://example.com/raw',
+        'contents_url' => 'https://example.com/contents',
+        'patch' => '@@ patch @@',
+        'previous_filename' => 'old.php',
+    ];
+
+    $file = File::fromArray($data);
+    $result = $file->toArray();
+
+    expect($result)->toBe($data);
+});


### PR DESCRIPTION
## Summary
- Created `File` DTO for file change information with helper methods (`isAdded()`, `isModified()`, `isRemoved()`, `isRenamed()`)
- Created `Commit` DTO for commit data including SHA, message, author/committer info
- Created `CommitAuthor` DTO for git-level author/committer details (name, email, date)
- Updated `files()` method to return `File[]` instead of raw arrays
- Updated `checks()` method to return `CheckRun[]` instead of raw arrays
- Updated `commits()` method to return `Commit[]` instead of raw arrays
- Added comprehensive test coverage for all new DTOs
- Updated existing tests to validate typed return values

All new DTOs follow the existing pattern with readonly properties, `fromArray()` factory methods, and `toArray()` serialization.

## Test Plan
- [x] Created unit tests for File DTO
- [x] Created unit tests for CommitAuthor DTO
- [x] Created unit tests for Commit DTO
- [x] Updated PullRequestWrapperTest to test typed returns
- [x] All tests passing (36 tests, 154 assertions)
- [x] PHPStan analysis passing (level 8)
- [x] Code style passing (Laravel Pint)

Fixes #5