### PR TITLE
chore: declare Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "conduit-ui/connector": "^1.0"
+        "php": "^8.3",
+        "conduit-ui/connector": "^1.0.1"
     },
     "require-dev": {
-        "illuminate/support": "^12.43",
+        "illuminate/support": "^12.43|^13.0",
         "laravel/pint": "^1.0",
         "pestphp/pest": "^3.0",
         "phpstan/extension-installer": "*",


### PR DESCRIPTION
## Summary
- Bumps PHP floor to 8.3 (Laravel 13 minimum)
- Widens \`illuminate/support\` dev-constraint to admit Laravel 13.x
- Pins \`conduit-ui/connector\` to \`^1.0.1\` — required to clear the three Saloon 3.x CVEs that block \`composer audit\` on Laravel 13 installs (CVE-2026-33942, CVE-2026-33183, CVE-2026-33182, all fixed in connector v1.0.1's Saloon 4 upgrade)

## Why no source changes
The package's runtime code only touches stable Illuminate surface — \`ServiceProvider\`, \`Collection\`, \`Facade\`. None of these changed shape between L12 and L13. Verified by running the test suite against \`illuminate/support v13.11.1\`.

## Verification

| Check | Result |
|---|---|
| \`./vendor/bin/pest\` against L13 | 310 passed (652 assertions) |
| \`./vendor/bin/pest\` against L12 baseline | 310 passed (same) |
| \`composer audit\` | No advisories |
| \`./vendor/bin/phpstan analyse\` | 16 errors — all pre-existing on master baseline, 0 new |

## Test plan
- [x] Verify Pest passes on Laravel 13
- [x] Verify Pest still passes on Laravel 12 baseline (constraint widening, not migration)
- [x] Verify composer audit is clean
- [x] Verify PHPStan baseline unchanged